### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "license-list"]
 	path = license-list
-	url = http://git.spdx.org/license-list.git
+	url = https://github.com/spdx/license-list


### PR DESCRIPTION
서브모듈 license-list의 주소가 바뀐 것 같아서 남깁니다.
redirect가 되긴 하지만, git clone 명령어로 내려받을 때 바로 받을 수 있도록 수정을 진행해두면 좋을 것 같습니다.